### PR TITLE
Changes in build. 

### DIFF
--- a/Samples/Voronoi/build.bat
+++ b/Samples/Voronoi/build.bat
@@ -1,12 +1,29 @@
-REM Copied from Fractals/build.bat with minor changes
 @echo off
-set SRC=main.c
-set EXE=main
+REM copied from Fractals/build.bat
+
 setlocal
+
+set SourceFiles=../main.c
+set OutputName=voronoi.exe
+
 pushd ..
 
+set CLFlags=-Od
+set CLANGFlags=-g -gcodeview
+set GCCFlags=-O
+
+if "%1" neq "optimize" goto DoneConfig
+set CLFlags=-O2
+set CLANGFlags=-O2 -gcodeview
+set GCCFlags=-O2
+
+echo -------------------------------------
+echo Optimize Build configured
+echo -------------------------------------
+:DoneConfig
+
 if not exist "Libraries" mkdir Libraries
-if exist "Libraries/SDL2" goto SkipDownload
+if exist "Libraries/SDL2" goto SkipDownloadSDL
 
 pushd Libraries
 mkdir SDL2
@@ -16,25 +33,42 @@ del SDL2.zip
 ren "SDL2\SDL2-2.0.14\include" "SDL2"
 popd
 
-:SkipDownload
+:SkipDownloadSDL
+
+if exist "Libraries/SDL2MinGw" goto SkipDownloadSDLMinGw
+
+pushd Libraries
+mkdir SDL2MinGw
+curl "https://www.libsdl.org/release/SDL2-devel-2.0.14-mingw.tar.gz" --output SDL2MinGw.tar.gz
+tar -xf SDL2MinGw.tar.gz -C SDL2MinGw
+del SDL2MinGw.tar.gz
+popd
+
+:SkipDownloadSDLMinGw
 popd
 
 set SDL2_Include="../../Libraries/SDL2/SDL2-2.0.14/SDL2/"
 set SDL2_Library="../../Libraries/SDL2/SDL2-2.0.14/lib/x64/"
 set SDL2_DLL="..\..\Libraries\SDL2\SDL2-2.0.14\lib\x64\SDL2.dll"
 
+set SDL2MinGw_Include="../../Libraries/SDL2MinGw/SDL2-2.0.14/i686-w64-mingw32/include/SDL2/"
+set SDL2MinGw_Library="../../Libraries/SDL2MinGw/SDL2-2.0.14/x86_64-w64-mingw32/lib/"
+set SDL2MinGw_DLL="..\..\Libraries\SDL2MinGw\SDL2-2.0.14\x86_64-w64-mingw32\bin\SDL2.dll"
+
 if not exist "bin" mkdir bin
 
 echo -------------------------------------
-xcopy %SDL2_DLL% bin\ /Y
 echo SDL2 inlude path:  %SDL2_Include%
 echo SDL2 library path: %SDL2_Library%
+echo SDL2MinGw inlude path:  %SDL2_Include%
+echo SDL2MinGw library path: %SDL2_Library%
 
 where cl >nul 2>nul
 if %ERRORLEVEL% neq 0 goto SkipMSVC
 echo Building with MSVC
 pushd bin
-call cl -I%SDL2_Include% -nologo -Zi -EHsc ../%SRC% /link /LIBPATH:%SDL2_Library% SDL2.lib SDL2main.lib Shell32.lib /subsystem:console
+xcopy %SDL2_DLL% .\ /Y
+call cl -I%SDL2_Include% -nologo %CLFlags% -Zi -EHsc %SourceFiles% -Fe%OutputName% /link /LIBPATH:%SDL2_Library% SDL2.lib SDL2main.lib Shell32.lib /subsystem:windows
 popd
 goto Finished
 
@@ -44,7 +78,8 @@ where clang >nul 2>nul
 IF %ERRORLEVEL% NEQ 0 goto SkipCLANG
 echo Building with CLANG
 pushd bin
-call clang -I%SDL2_Include% -L%SDL2_Library% ../%SRC% -o %EXE% -lSDL2.lib -lSDL2main.lib -lShell32.lib
+xcopy %SDL2_DLL% .\ /Y
+call clang -I%SDL2_Include% -L%SDL2_Library% %CLANGFlags% %SourceFiles% -o %OutputName% -lSDL2main -lSDL2 -lShell32 -Xlinker -subsystem:windows
 popd
 goto Finished
 
@@ -54,7 +89,8 @@ where gcc >nul 2>nul
 IF %ERRORLEVEL% NEQ 0 goto SkipGCC
 echo Building with GCC
 pushd bin
-call gcc -I%SDL2_Include% -L%SDL2_Library% ../%main% -o %EXE% -lSDL2.lib -lSDL2main.lib -lShell32.lib
+xcopy %SDL2MinGw_DLL% .\ /Y
+call gcc -I%SDL2MinGw_Include% -L%SDL2MinGw_Library% %GCCFlags% %SourceFiles% -o %OutputName% -w -Wl,-subsystem,windows -lmingw32 -lSDL2main -lSDL2
 popd
 goto Finished
 

--- a/Samples/Voronoi/build.sh
+++ b/Samples/Voronoi/build.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 mkdir -p ./bin
-# e.g.
-INCLUDE="${HOME}/libraries/SDL2-2.0.14/include"
-#INCLUDE=""
+# Enter your SDL include directory here. SDL.h must exist in this directory and not in any other subdirectory
+# e.g. INCLUDE="${HOME}/libraries/SDL2-2.0.14/include"
+INCLUDE=""
 CC=""
 compile_command=""
 SRC="main.c"
+BIN_NAME="voronoi"
+
 echo "Checking if gcc exists...."
 if gcc -v >/dev/null 2>&1; then
   echo "gcc exists. Compiling with gcc."
@@ -30,13 +32,12 @@ else
   compile_command="$CC -g"
 fi
 
-if [ "${INCLUDE}" = "" ]; then
-  echo "Warning: INCLUDE directory not set!"
-else
-  compile_command="${compile_command} -I${INCLUDE}"  
-fi
-
-compile_command="${compile_command} -o ./bin/main ${SRC} -lSDL2"
+while [ ! -f "${INCLUDE}/SDL.h" ]
+do
+  echo "SDL.h not found in the provided directory"
+  read -p "Enter you SDL directory here: " INCLUDE
+done
+compile_command="${compile_command} -I${INCLUDE} -o ./bin/${BIN_NAME} ${SRC} -lSDL2"
 echo $compile_command
 if eval $compile_command ; then
   echo "Compilation finished successfully!"

--- a/Samples/Voronoi/main.c
+++ b/Samples/Voronoi/main.c
@@ -492,9 +492,15 @@ void insert_vonoroi_point(Vonoroi *v, v2 point) {
   // Find the vonoroi region for the point
   int index = find_vonoroi_region(v, point);
   assert(index != -1);
-
-  v2 site = v->sites[index];
+  
   Region *r = v->region_list[index];
+  v2 site = r->site;
+  
+  if ( fabs(point.x-site.x) < EPSILON && fabs(point.y-site.y) < EPSILON ){
+    fprintf( stderr, "Input point too close to existing site. Ignoring..\n" );
+    return;
+  }
+  
   arrpush(v->sites, point);
 
   Line l = perpendicular_bisector(point, site);


### PR DESCRIPTION
GCC build in windows links with libraries in x86_64-w64-mingw32 instead of i686-w64-mingw32. Most likely due to different versions of mingw. 