### PR TITLE
Fixed Visual Studio Macro bug

### DIFF
--- a/Samples/Mandelbrot-DX11/Mandelbrot-DX11.vcxproj
+++ b/Samples/Mandelbrot-DX11/Mandelbrot-DX11.vcxproj
@@ -102,7 +102,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "mandelbrot.hlsl" $(OutputPath) /Y
+      <Command>xcopy "mandelbrot.hlsl" "$(OutputPath)" /Y
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -122,7 +122,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "mandelbrot.hlsl" $(OutputPath) /Y
+      <Command>xcopy "mandelbrot.hlsl" "$(OutputPath)" /Y
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -138,7 +138,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "mandelbrot.hlsl" $(OutputPath) /Y
+      <Command>xcopy "mandelbrot.hlsl" "$(OutputPath)" /Y
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -158,7 +158,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "mandelbrot.hlsl" $(OutputPath) /Y
+      <Command>xcopy "mandelbrot.hlsl" "$(OutputPath)" /Y
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Changed $(OutputPath) to "$(OutputPath)" because windows